### PR TITLE
Switch tests to gtest style

### DIFF
--- a/AndyCADMFC/core/utils/CPoint.hpp
+++ b/AndyCADMFC/core/utils/CPoint.hpp
@@ -1,7 +1,14 @@
+#ifndef ANDYCAD_CORE_UTILS_CPOINT_HPP
+#define ANDYCAD_CORE_UTILS_CPOINT_HPP
+#pragma once
+
 struct CPoint {
     double x = 0;
     double y = 0;
 
     CPoint() = default;
     CPoint(double x, double y) : x(x), y(y) {}
+
 };
+
+#endif // ANDYCAD_CORE_UTILS_CPOINT_HPP

--- a/AndyCADMFC/core/utils/CRect.hpp
+++ b/AndyCADMFC/core/utils/CRect.hpp
@@ -42,3 +42,6 @@ struct Rect {
 }
 };
 
+// For compatibility with old MFC-style naming
+using CRect = Rect;
+

--- a/AndyCADMFC/core/utils/CSize.hpp
+++ b/AndyCADMFC/core/utils/CSize.hpp
@@ -1,7 +1,14 @@
+#ifndef ANDYCAD_CORE_UTILS_CSIZE_HPP
+#define ANDYCAD_CORE_UTILS_CSIZE_HPP
+#pragma once
+
 struct CSize {
     double cx = 0;
     double cy = 0;
 
     CSize() = default;
     CSize(double x, double y) : cx(x), cy(y) {}
+
 };
+
+#endif // ANDYCAD_CORE_UTILS_CSIZE_HPP

--- a/tests/gtest/gtest.h
+++ b/tests/gtest/gtest.h
@@ -1,0 +1,62 @@
+#ifndef GTEST_LITE_H
+#define GTEST_LITE_H
+#include <vector>
+#include <iostream>
+#include <cmath>
+#include <cstdlib>
+
+namespace gtest {
+struct TestInfo {
+    const char* case_name;
+    const char* test_name;
+    void (*func)();
+};
+
+inline int& failure_count() {
+    static int f = 0;
+    return f;
+}
+
+inline std::vector<TestInfo>& registry() {
+    static std::vector<TestInfo> r;
+    return r;
+}
+
+inline void RegisterTest(const char* case_name, const char* test_name, void(*func)()) {
+    registry().push_back({case_name, test_name, func});
+}
+
+inline void ReportFailure(const char* expr, const char* file, int line) {
+    std::cout << file << ":" << line << ": Failure\n  Expected: " << expr << std::endl;
+    failure_count()++;
+}
+
+inline int RunAllTests() {
+    failure_count() = 0;
+    for (auto& t : registry()) {
+        std::cout << "[ RUN      ] " << t.case_name << "." << t.test_name << std::endl;
+        t.func();
+    }
+    std::cout << "[==========] " << registry().size() << " tests ran." << std::endl;
+    std::cout << "[  PASSED  ] " << (registry().size() - failure_count()) << " tests." << std::endl;
+    if (failure_count()) std::cout << "[  FAILED  ] " << failure_count() << " tests." << std::endl;
+    return failure_count();
+}
+}
+
+#define TEST(case_name, test_name) \
+    void case_name##_##test_name(); \
+    namespace { \
+    struct case_name##_##test_name##_registrar { \
+        case_name##_##test_name##_registrar() { \
+            gtest::RegisterTest(#case_name, #test_name, &case_name##_##test_name); \
+        } \
+    } case_name##_##test_name##_registrar_instance; \
+    } \
+    void case_name##_##test_name()
+
+#define EXPECT_TRUE(x) do { if(!(x)) gtest::ReportFailure(#x, __FILE__, __LINE__); } while(0)
+#define EXPECT_EQ(a,b) do { if(!((a)==(b))) gtest::ReportFailure(#a " == " #b, __FILE__, __LINE__); } while(0)
+#define EXPECT_NEAR(a,b,eps) do { if(!(std::fabs((a)-(b)) <= (eps))) gtest::ReportFailure("fabs(" #a "-" #b ") <= " #eps, __FILE__, __LINE__); } while(0)
+
+#endif // GTEST_LITE_H

--- a/tests/primitives_test.cpp
+++ b/tests/primitives_test.cpp
@@ -1,0 +1,39 @@
+#include "AndyCADMFC/core/utils/CRect.hpp"
+#include "gtest/gtest.h"
+
+TEST(Primitives, CPoint) {
+    CPoint p1;
+    EXPECT_EQ(p1.x, 0);
+    EXPECT_EQ(p1.y, 0);
+    CPoint p2(3.0, 4.0);
+    EXPECT_EQ(p2.x, 3.0);
+    EXPECT_EQ(p2.y, 4.0);
+}
+
+TEST(Primitives, CSize) {
+    CSize s1;
+    EXPECT_EQ(s1.cx, 0);
+    EXPECT_EQ(s1.cy, 0);
+    CSize s2(5.0, 6.0);
+    EXPECT_EQ(s2.cx, 5.0);
+    EXPECT_EQ(s2.cy, 6.0);
+}
+
+TEST(Primitives, RectBasics) {
+    Rect r1(0, 0, 10, 10);
+    EXPECT_EQ(r1.width(), 10);
+    EXPECT_EQ(r1.height(), 10);
+    EXPECT_TRUE(r1.contains({5,5}));
+    EXPECT_TRUE(!r1.contains({10,10}));
+
+    r1.normalize();
+    EXPECT_TRUE(!r1.isEmpty());
+
+    Rect r2 = r1.operator Rect();
+    EXPECT_TRUE(r2.left < r1.left);
+    EXPECT_TRUE(r2.right > r1.right);
+}
+
+int main() {
+    return gtest::RunAllTests();
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+DIR="$(dirname "$0")"
+cd "$DIR"
+g++ -std=c++17 primitives_test.cpp -I.. -I./gtest -o primitives_test
+./primitives_test


### PR DESCRIPTION
## Summary
- switch primitive tests to use a minimal Google Test header
- add header-only test harness under `tests/gtest`
- update test script to compile with the gtest header

## Testing
- `cd tests && ./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68403f298ed8832985ae852d54827b7e